### PR TITLE
preliminary distributed logging support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,5 +4,6 @@ authors = ["Luke Adams <lukeclydeadams@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/src/EnhancedLogging.jl
+++ b/src/EnhancedLogging.jl
@@ -1,12 +1,13 @@
 module EnhancedLogging
 
-using Printf, Logging
+using Printf, Logging, Distributed
 import Logging: handle_message, shouldlog, min_enabled_level, catch_exceptions, LogLevel
 
-export ProgressLevel, EnhancedConsoleLogger
+export ProgressLevel, EnhancedConsoleLogger, WorkerLogger
 
 const ProgressLevel = LogLevel(-1)
 
 include("EnhancedConsoleLogger.jl")
+include("WorkerLogger.jl")
 
 end # module

--- a/src/WorkerLogger.jl
+++ b/src/WorkerLogger.jl
@@ -1,0 +1,26 @@
+"""
+Sends all log records to the global logger on the master process. An additional
+keyword argument, `_pid=myid()` is also passed.
+"""
+struct WorkerLogger <: AbstractLogger end
+function WorkerLogger(logger::AbstractLogger)
+    if myid() == 1
+        return logger
+    end
+
+    return WorkerLogger()
+end
+
+function recieve_log_msg(pid, args...; kwargs...)
+    handle_message(global_logger(), args...; _pid=pid, kwargs...)
+    nothing
+end
+
+function handle_message(logger::WorkerLogger, args...; kwargs...)
+    remotecall_fetch(EnhancedLogging.recieve_log_msg, 1, myid(), args...; kwargs...)
+    nothing
+end
+
+shouldlog(::WorkerLogger, args...) = true
+min_enabled_level(::WorkerLogger) = Base.CoreLogging.BelowMinLevel
+catch_exceptions(::WorkerLogger) = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ end
     @debug "hello world"
     @logmsg ProgressLevel "status report" progress=0.32 _overwrite=true
     @logmsg ProgressLevel "status report" _overwrite=true
+    @logmsg ProgressLevel "this is a really really long status report that goes on forever" progress=0.32 _overwrite=true _showlocation=true
     @info "everything seems to be fine..."
     @info "everything seems to be fine...\nand its fine on this line...\nand this line...\nand also this line" asdf=2
     @warn "ummm this doesn't look good"
@@ -19,7 +20,7 @@ end
 
     for i in 0:0.001:1
         @logmsg ProgressLevel "hello" progress=i _overwrite=true
-        sleep(0.005)
+        sleep(0.001)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,13 @@
-using Logging, EnhancedLogging
+using Distributed, Logging, EnhancedLogging
+addprocs(1)
 
-function test_logging()
+global_logger(EnhancedConsoleLogger())
+@everywhere begin
+    using Logging, EnhancedLogging
+    global_logger(WorkerLogger(global_logger()))
+end
+
+@everywhere function test_logging()
     @debug "hello world"
     @logmsg ProgressLevel "status report" progress=0.32 _overwrite=true
     @logmsg ProgressLevel "status report" _overwrite=true
@@ -17,3 +24,6 @@ function test_logging()
 end
 
 with_logger(test_logging, EnhancedConsoleLogger())
+
+
+remotecall_fetch(test_logging, 2)


### PR DESCRIPTION
This uses the global logger on both the master and worker processes. It
would be preferable if this also worked with the with_logger function,
but that will require much more work.

Ref #1.